### PR TITLE
fix: RemoteAddr returns ip with port that changes each time so we should get ip without port

### DIFF
--- a/src/api/middleware/otp_limiter.go
+++ b/src/api/middleware/otp_limiter.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 func OtpLimiter(cfg *config.Config) gin.HandlerFunc {
 	var limiter = limiter.NewIPRateLimiter(rate.Every(cfg.Otp.Limiter*time.Second), 1)
 	return func(c *gin.Context) {
-		limiter := limiter.GetLimiter(c.Request.RemoteAddr)
+		limiter := limiter.GetLimiter(getIP(c.Request.RemoteAddr))
 		if !limiter.Allow() {
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, helper.GenerateBaseResponseWithError(nil, false, helper.OtpLimiterError, errors.New("not allowed")))
 			c.Abort()
@@ -23,4 +24,12 @@ func OtpLimiter(cfg *config.Config) gin.HandlerFunc {
 			c.Next()
 		}
 	}
+}
+
+func getIP(remoteAddr string) string {
+    ip, _, err := net.SplitHostPort(remoteAddr)
+    if err != nil {
+        return remoteAddr
+    }
+    return ip
 }


### PR DESCRIPTION
RemoteAddr returns ip with port that changes each time so we should get ip without port