### PR TITLE
Fix: fix libc problem to build docker file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -124,10 +124,10 @@ curl -X 'POST' \
 docker compose -f "docker/docker-compose.yml" up -d --build
 ```
 
-#### Web API  Run in docker  [http://localhost:9001](http://localhost:9001)
+#### Web API  Run in docker  [http://localhost:9002](http://localhost:9002)
 
 ```
-Token Url: http://localhost:9001/api/v1/users/login-by-username
+Token Url: http://localhost:9002/api/v1/users/login-by-username
 Username: admin
 Password: 12345678
 ```

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.19-buster AS builder
+FROM golang:1.22-bookworm AS builder
 
 WORKDIR /app
 
 COPY go.* ./
+ENV CGO_ENABLED=0
+RUN go env -w GO111MODULE=on
+RUN go env -w GOPROXY=https://goproxy.cn,direct
 RUN go mod download
 
 COPY . ./
@@ -17,8 +20,7 @@ COPY --from=builder /app/server /app/server
 COPY --from=builder /app/config/config-docker.yml /app/config/config-docker.yml
 COPY --from=builder /app/docs /app/docs
 
-ENV APP_ENV docker
-ENV PORT ${Port}
+ENV APP_ENV=docker
+ENV PORT=${Port}
 
 CMD [ "/app/server" ]
- 


### PR DESCRIPTION
Close #12 

1. Add goproxy
2. fix `libc` problem to build the web API docker file